### PR TITLE
fix(ci): fix goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,15 +31,6 @@ builds:
       - -X "${GoPackageName}/cmd/root.description=${Description}"
 archives:
   - name_template: "${ProjectName}_{{.Version}}_{{.Os}}_{{.Arch}}{{if .Arm}}v{{.Arm}}{{end}}"
-    replacements:
-      darwin: "darwin"
-      linux: "linux"
-      windows: "windows"
-      386: "i386"
-      amd64: "x86_64"
-    format_overrides:
-      - goos: "windows"
-        format: "zip"
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -50,13 +41,6 @@ nfpms:
   -
     id: "${ProjectName}"
     package_name: "${ProjectName}"
-
-    replacements:
-      amd64: "64-bit"
-      386: "32-bit"
-      darwin: "macOS"
-      linux: "linux"
-
     homepage: "${HomePage}"
     maintainer: "${Author} <${AuthorEmail}>"
     description: "A template for golang"


### PR DESCRIPTION
## Description

## Problem
goreleaser was not building the binary.

## Solution
Remove the deprecated `replacement` setting

## Notes
Other notes that you want to share but do not fit into _Problem_ or _Solution_.

